### PR TITLE
feat: :sparkles: introduced extensible attributes for infoblox

### DIFF
--- a/pkg/controller/provider/infoblox/access.go
+++ b/pkg/controller/provider/infoblox/access.go
@@ -35,16 +35,18 @@ type access struct {
 	requestBuilder ibclient.HttpRequestBuilder
 	metrics        provider.Metrics
 	view           string
+	extattrs       ibclient.EA
 }
 
 var _ raw.Executor = (*access)(nil)
 
-func NewAccess(client ibclient.IBConnector, requestBuilder ibclient.HttpRequestBuilder, view string, metrics provider.Metrics) *access {
+func NewAccess(client ibclient.IBConnector, requestBuilder ibclient.HttpRequestBuilder, view string, metrics provider.Metrics, ea ibclient.EA) *access {
 	return &access{
 		IBConnector:    client,
 		requestBuilder: requestBuilder,
 		metrics:        metrics,
 		view:           view,
+		extattrs:       ea,
 	}
 }
 
@@ -73,18 +75,21 @@ func (this *access) NewRecord(fqdn string, rtype string, value string, zone prov
 		r.Name = fqdn
 		r.Ipv4Addr = value
 		r.View = this.view
+		r.Ea = this.extattrs
 		record = (*RecordA)(r)
 	case dns.RS_AAAA:
 		r := ibclient.NewEmptyRecordAAAA()
 		r.Name = fqdn
 		r.Ipv6Addr = value
 		r.View = this.view
+		r.Ea = this.extattrs
 		record = (*RecordAAAA)(r)
 	case dns.RS_CNAME:
 		r := ibclient.NewEmptyRecordCNAME()
 		r.Name = fqdn
 		r.Canonical = value
 		r.View = this.view
+		r.Ea = this.extattrs
 		record = (*RecordCNAME)(r)
 	case dns.RS_TXT:
 		if n, err := strconv.Unquote(value); err == nil && !strings.Contains(value, " ") {
@@ -94,6 +99,7 @@ func (this *access) NewRecord(fqdn string, rtype string, value string, zone prov
 		r.Name = fqdn
 		r.Text = value
 		r.View = this.view
+		r.Ea = this.extattrs
 		record = (*RecordTXT)(r)
 	}
 	if record != nil {

--- a/pkg/controller/provider/infoblox/handler.go
+++ b/pkg/controller/provider/infoblox/handler.go
@@ -43,16 +43,17 @@ type Handler struct {
 }
 
 type InfobloxConfig struct {
-	Host            *string `json:"host,omitempty"`
-	Port            *int    `json:"port,omitempty"`
-	SSLVerify       *bool   `json:"sslVerify,omitempty"`
-	Version         *string `json:"version,omitempty"`
-	View            *string `json:"view,omitempty"`
-	PoolConnections *int    `json:"httpPoolConnections,omitempty"`
-	RequestTimeout  *int    `json:"httpRequestTimeout,omitempty"`
-	CaCert          *string `json:"caCert,omitempty"`
-	MaxResults      int     `json:"maxResults,omitempty"`
-	ProxyURL        *string `json:"proxyUrl,omitempty"`
+	Host            *string     `json:"host,omitempty"`
+	Port            *int        `json:"port,omitempty"`
+	SSLVerify       *bool       `json:"sslVerify,omitempty"`
+	Version         *string     `json:"version,omitempty"`
+	View            *string     `json:"view,omitempty"`
+	PoolConnections *int        `json:"httpPoolConnections,omitempty"`
+	RequestTimeout  *int        `json:"httpRequestTimeout,omitempty"`
+	CaCert          *string     `json:"caCert,omitempty"`
+	MaxResults      int         `json:"maxResults,omitempty"`
+	ProxyURL        *string     `json:"proxyUrl,omitempty"`
+	Extattrs        ibclient.EA `json:"extAttrs,omitempty"`
 }
 
 var _ provider.DNSHandler = &Handler{}
@@ -162,7 +163,7 @@ func NewHandler(config *provider.DNSHandlerConfig) (provider.DNSHandler, error) 
 		return nil, err
 	}
 
-	h.access = NewAccess(client, requestBuilder, *h.infobloxConfig.View, config.Metrics)
+	h.access = NewAccess(client, requestBuilder, *h.infobloxConfig.View, config.Metrics, infobloxConfig.Extattrs)
 
 	h.ZoneCache, err = config.ZoneCacheFactory.CreateZoneCache(provider.CacheZonesOnly, config.Metrics, h.getZones, h.getZoneState)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces extetensible attributes, which can be added to a request to infoblox devices and which are mandatory in some cases.
Before this change, it was not possible to create records for infoblox devices, which require extensible attributes.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
